### PR TITLE
fix(README): fix wrong install instruction for Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pod 'TweaKit', '~> 1.0'
 ### Carthage
 
 ```ogdl
-github 'Alpensegler/TweaKit' ~> 1.0
+github "Alpensegler/TweaKit" ~> 1.0
 ```
 
 ### Swift Package Manager


### PR DESCRIPTION
## Description
This PR fix the wrong install instruction for Carthage. Using single quote would cause error: 
> expected string after dependency type in line: github 'Alpensegler/TweaKit' ~> 1.0

## Issue Link
#2 
