### PR TITLE
fix(ui): fix tweak list crash after scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Crash after tweak list scroll animation end on iOS 16
 
 ## [1.0.3] - 2022-11-16
 ### Fixed

--- a/Sources/UI/List/TweakListViewController.swift
+++ b/Sources/UI/List/TweakListViewController.swift
@@ -132,7 +132,13 @@ extension TweakListViewController {
 
 extension TweakListViewController {
     public override func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-        super.scrollViewDidEndScrollingAnimation(scrollView)
+        if #unavailable(iOS 16.0) {
+            // Starting from iOS 16, calling super.scrollViewDidEndScrollingAnimation(scrollView) would result in a unrecognized selector exception
+            // This is an optional method from the UIScrollViewDelegate, so probably UITableViewController does not implement this method anymore
+            // There is no need call it with super then
+            super.scrollViewDidEndScrollingAnimation(scrollView)
+        }
+
         if let indexPath = locatedIndexPath {
             _highlightLocatedTweak(at: indexPath)
             locatedIndexPath = nil


### PR DESCRIPTION
## Description
This PR fixes a crash after tweak list scroll animation end on iOS 16. See comments for details.

Kudos to @pinlin168 for helping to find and investigate the bug!