### PR TITLE
fix(ui): fix secondary may not show from floating panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Tweak secondary view may not show from floating panel.
 
 ### [1.0.4] - 2023-08-29
 ### Fixed
-- Crash after tweak list scroll animation end on iOS 16
+- Crash after tweak list scroll animation end on iOS 16.
 
 ## [1.0.3] - 2022-11-16
 ### Fixed

--- a/Sources/UI/Floating/TweakFloatingBall.swift
+++ b/Sources/UI/Floating/TweakFloatingBall.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class TweakFloatingBall: UIView {
     private unowned var context: TweakContext
+    private let origin: TweakFloatingOrigin
     private var tweaks: [AnyTweak] = []
 
     private lazy var dashLayer = _dashLayer()
@@ -27,8 +28,9 @@ final class TweakFloatingBall: UIView {
         _unregisterNotifications()
     }
 
-    init(context: TweakContext) {
+    init(context: TweakContext, origin: TweakFloatingOrigin) {
         self.context = context
+        self.origin = origin
         super.init(frame: .init(x: 0, y: 0, width: Constants.UI.Floating.ballSize, height: Constants.UI.Floating.ballSize))
         _registerNotifications()
         _setupUI()
@@ -236,7 +238,7 @@ private extension TweakFloatingBall {
 
     func _toPanel() {
         isUserInteractionEnabled = false
-        context.floatingTransitioner?.animateTransition(from: self, to: TweakFloatingPanel(context: context), tweaks: tweaks)
+        context.floatingTransitioner?.animateTransition(from: self, to: TweakFloatingPanel(context: context, origin: origin), tweaks: tweaks)
     }
 
     func _toList() {

--- a/Sources/UI/Floating/TweakFloatingPanel.swift
+++ b/Sources/UI/Floating/TweakFloatingPanel.swift
@@ -24,9 +24,11 @@ final class TweakFloatingPanel: UIViewController {
     private var heightLevel: HeightLevel = .medium
 
     private unowned let context: TweakContext
+    private let origin: TweakFloatingOrigin
 
-    init(context: TweakContext) {
+    init(context: TweakContext, origin: TweakFloatingOrigin) {
         self.context = context
+        self.origin = origin
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -423,7 +425,7 @@ private extension TweakFloatingPanel {
 
 private extension TweakFloatingPanel {
     @objc func _transitToBall(_ sender: UIButton) {
-        context.floatingTransitioner?.animateTransition(from: self, to: TweakFloatingBall(context: context), tweaks: tweaks)
+        context.floatingTransitioner?.animateTransition(from: self, to: TweakFloatingBall(context: context, origin: origin), tweaks: tweaks)
     }
 
     @objc func _transitToList(_ sender: UIButton) {
@@ -480,7 +482,7 @@ private extension TweakFloatingPanel {
     }
 
     func _tweakListViewController() -> TweakListViewController {
-        let v = TweakListViewController(scene: .floating)
+        let v = TweakListViewController(scene: .floating(origin: origin))
         v.tableView.showsVerticalScrollIndicator = false
         return v
     }

--- a/Sources/UI/List/TweakListViewScene.swift
+++ b/Sources/UI/List/TweakListViewScene.swift
@@ -10,7 +10,12 @@ import Foundation
 enum TweakListViewScene {
     case list(name: String)
     case search(keyword: String)
-    case floating
+    case floating(origin: TweakFloatingOrigin)
+}
+
+enum TweakFloatingOrigin {
+    case list
+    case search
 }
 
 extension TweakListViewScene {


### PR DESCRIPTION
## Description

In current implementation, when presenting tweak secondary view from floating panel, we are using the tweak window's root vc as the presenting vc. But if the floating panel is activated from search result, the  tweak window's root vc is already presenting the tweak search vc, and in this case, it can not present another vc, resulting the  tweak secondary view not show.

In this PR, we change the presenting vc to the tweak search vc in this scenario to fix the presentation issue.

## Issue Link

https://github.com/Alpensegler/TweaKit/issues/6